### PR TITLE
Tweak grammar for 'rollback'

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -58,7 +58,7 @@ function run(params, cliLog) {
 			debug('Applying migrations');
 			return applyMigrations(params.folder, params.migration);
 		} else if (params.action === 'down') {
-			debug('Rollbacking migrations');
+			debug('Rolling back migrations');
 			return rollbackMigrations(params.folder, params.migration);
 		}
 	});
@@ -207,7 +207,7 @@ function applyMigrations(folder) {
 				onError: function (err, failedBatch, migration) {
 					failedBatch.status = Migration.STATUS.FAILED;
 					return savePromise(failedBatch).then(function () {
-						log.error('Migration ' + migration + ' failed, rollbacking...');
+						log.error('Migration ' + migration + ' failed, rolling back...');
 						log.error(err.stack);
 						return rollbackMigrations(folder, true);
 					});
@@ -288,7 +288,7 @@ function rollbackMigrations(folder, isError) {
 
 	}).then(function () {
 		if (isError) {
-			throw new MigrationError('Rollbacked on error!');
+			throw new MigrationError('Rolled back on error!');
 		}
 	});
 }
@@ -306,8 +306,8 @@ function runMigrations(migrationsToRun, controlDoc, options) {
 			at: controlDoc.batch.at
 		}
 	}),
-		doing = options.direction === Migration.DIRECTION.UP ? 'Applying': 'Rollbacking',
-		done = options.direction === Migration.DIRECTION.UP ? 'Applied': 'Rollbacked',
+		doing = options.direction === Migration.DIRECTION.UP ? 'Applying': 'Rolling back',
+		done = options.direction === Migration.DIRECTION.UP ? 'Applied': 'Rolled back',
 		promise = Q.when();
 
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -23,7 +23,7 @@ function schemaFn(mongoose, collection) {
 			at: Date
 		},
 		// The last fully alive batch, that is, the last completed 'up' batch
-		// that hasn't been rollbacked.
+		// that hasn't been rolled back.
 		// This is basically the tail of the migration history
 		batch: {
 			_id: mongoose.Schema.ObjectId,
@@ -34,11 +34,11 @@ function schemaFn(mongoose, collection) {
 		// Batches only
 
 		at: Date,
-		// Last run/rollbacked migration of this batch
+		// Last run/rolled-back migration of this batch
 		migration: String,
 		status: String,
 		direction: String,
-		// The batch this one is continuing or rollbacking
+		// The batch this one is continuing or rolling back
 		prevBatch: {
 			_id: mongoose.Schema.ObjectId,
 			migration: String,

--- a/lib/template.js
+++ b/lib/template.js
@@ -7,6 +7,6 @@ exports.up = function (next) {
 
 
 exports.down = function (next) {
-	console.log('    --> This is migration {{name}} being rollbacked');
+	console.log('    --> This is migration {{name}} being rolled back');
 	next();
 };

--- a/test/failing-migration-rollback.js
+++ b/test/failing-migration-rollback.js
@@ -7,6 +7,6 @@ exports.up = function (next) {
 
 
 exports.down = function (next) {
-	console.log('    --> This is migration {{name}} being rollbacked and failing');
+	console.log('    --> This is migration {{name}} being rolled back and failing');
 	next(new Error('some_error from {{name}}'));
 };

--- a/test/failing-migration.js
+++ b/test/failing-migration.js
@@ -7,6 +7,6 @@ exports.up = function (next) {
 
 
 exports.down = function (next) {
-	console.log('    --> This is migration {{name}} being rollbacked');
+	console.log('    --> This is migration {{name}} being rolled back');
 	next();
 };

--- a/test/failing-rollback.js
+++ b/test/failing-rollback.js
@@ -7,6 +7,6 @@ exports.up = function (next) {
 
 
 exports.down = function (next) {
-	console.log('    --> This is migration {{name}} being rollbacked and failing');
+	console.log('    --> This is migration {{name}} being rolled back and failing');
 	next(new Error('some_error from {{name}}'));
 };

--- a/test/migrate_spec.js
+++ b/test/migrate_spec.js
@@ -428,7 +428,7 @@ describe('migrate', function () {
 			})
 			.then(shouldFail, function (err) {
 				expect(err).toBeDefined();
-				expect(err.message).toMatch(/Rollbacked on error/);
+				expect(err.message).toMatch(/Rolled back on error/);
 			})
 			.then(findMigrations)
 			.spread(function (controlDoc, batches) {
@@ -449,7 +449,7 @@ describe('migrate', function () {
 			})
 			.then(shouldFail, function (err) {
 				expect(err).toBeDefined();
-				expect(err.message).toMatch(/Rollbacked on error/);
+				expect(err.message).toMatch(/Rolled back on error/);
 			})
 			.then(findMigrations)
 			.spread(function (controlDoc, batches) {
@@ -483,7 +483,7 @@ describe('migrate', function () {
 			})
 			.then(shouldFail, function (err) {
 				expect(err).toBeDefined();
-				expect(err.message).toMatch(/Rollbacked on error/);
+				expect(err.message).toMatch(/Rolled back on error/);
 			})
 			.then(function () {
 				createMigrations('5');


### PR DESCRIPTION
This tweaks the grammar to avoid using rollback as a verb directly. I think this makes the English easier to understand.
