### PR TITLE
Fix peer dependency of mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "rimraf": "^2.2.8"
   },
   "peerDependencies": {
-    "mongoose": "3.8.x"
+    "mongoose": ">= 3.8.x"
   }
 }


### PR DESCRIPTION
This allows people to install data migrate with a higher version of mongoose
