### PR TITLE
Do not use fixed version of mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,7 @@
   "devDependencies": {
     "jasmine-node": "^1.14.5",
     "mongodb": "^1.4.30",
-    "mongoose": "3.8.x",
+    "mongoose": "^3.8.x",
     "rimraf": "^2.2.8"
-  },
-  "peerDependencies": {
-    "mongoose": ">= 3.8.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "jasmine-node": "^1.14.5",
     "mongodb": "^1.4.30",
-    "mongoose": "^3.8.x",
+    "mongoose": ">= 3.8.0",
     "rimraf": "^2.2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "jasmine-node test/"
   },
   "dependencies": {
-    "cli": "^0.6.5",
+    "cli": "^1.0.1",
     "debug": "^2.1.1",
     "lodash": "^3.1.0",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
Currently the package requires fixed version of mongoose that us behind current version (4.4.19). It caused issues with shrinkwrap if newer version is used in the project.

Also is peer dependency of mongoose really needed here?
