### PR TITLE
Add dbOptions configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ module.exports = {
 	// See: http://mongoosejs.com/docs/connections.html
 	db: 'mongodb://localhost:27017',
 
+	// mongodb connection options in mongoose format (optional): 'mongodb://username:password@host:port/database?options...'
+	// See: http://mongoosejs.com/docs/connections.html
+	dbOptions: {},
+
 	// Name for the migrations collection (defaults to 'migrations')
 	collection: 'migrations'
 };

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -98,7 +98,7 @@ function getMongoose(config, params) {
 
 	debug('Connecting to mongo');
 
-	mongoose.connect(config.db);
+	mongoose.connect(config.db, config.dbOptions);
 
 	connectionDeferred = Q.defer();
 


### PR DESCRIPTION
This allows the options param of mongoose connect to be used. For instance if you need mongos (shard) config